### PR TITLE
feat: more restrictions and package bump

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -2,6 +2,18 @@
 
 The htsget auth service handles authorization based on the htsget-rs authorization [flow][htsget-auth].
 
+This is a service that reads `Cognito` JWT tokens and chooses a htsget-rs restriction based on the group that
+the user is in. Currently the following regions are allowed to be viewed for the `curators` group and everything
+else is disallowed:
+
+https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198804;r=MT:5874-7475;t=ENST00000361624
+https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000133703;r=12:25205246-25250936
+https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000139618;r=13:32315086-32400268
+https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000012048;r=17:43044292-43170245
+
+All other users can view any part of a file. Currently, these are just hard-coded example values, and would
+change based on real requirements.
+
 This project is written as a [Rust][rust] workspace, and contains a Makefile to simplify development.
 
 To get started run:

--- a/app/htsget-auth/src/router.rs
+++ b/app/htsget-auth/src/router.rs
@@ -118,21 +118,39 @@ pub async fn auth(headers: HeaderMap, state: State<AppState>) -> Result<Json<Aut
         AuthorizationRestrictionsBuilder::default()
             .rule(AuthorizationRuleBuilder::default().path(".*").build()?)
             .build()?
-    } else if groups.contains(&"curators_test") {
-        // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198804;r=MT:5874-7475;t=ENST00000361624
-        AuthorizationRestrictionsBuilder::default()
-            .rule(
+    } else if groups.contains(&"curators") {
+        let create_rule = |start: u32, end: u32, name: &str| {
+            Ok::<_, Error>(
                 AuthorizationRuleBuilder::default()
                     .path(".*")
                     .reference_name(
                         ReferenceNameRestrictionBuilder::default()
-                            .name("chrM")
-                            .start(5904)
-                            .end(7445)
+                            .name(name)
+                            .start(start)
+                            .end(end)
                             .build()?,
                     )
                     .build()?,
             )
+        };
+        // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198804;r=MT:5874-7475;t=ENST00000361624
+        AuthorizationRestrictionsBuilder::default()
+            .rules(vec![
+                // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000198804;r=MT:5874-7475;t=ENST00000361624
+                create_rule(5904, 7445, "chrM")?,
+                create_rule(5904, 7445, "M")?,
+                create_rule(5904, 7445, "chrMT")?,
+                create_rule(5904, 7445, "MT")?,
+                // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000133703;r=12:25205246-25250936
+                create_rule(25205246, 25250936, "chr12")?,
+                create_rule(25205246, 25250936, "12")?,
+                // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000139618;r=13:32315086-32400268
+                create_rule(32315086, 32400268, "chr13")?,
+                create_rule(32315086, 32400268, "13")?,
+                // https://asia.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=ENSG00000012048;r=17:43044292-43170245
+                create_rule(43044292, 43170245, "chr17")?,
+                create_rule(43044292, 43170245, "17")?,
+            ])
             .build()?
     } else {
         AuthorizationRestrictionsBuilder::default()

--- a/infrastructure/stage/htsget-stack.ts
+++ b/infrastructure/stage/htsget-stack.ts
@@ -180,6 +180,8 @@ export class HtsgetStack extends Stack {
           HTSGET_AUTH_VALIDATE_AUDIENCE: `[${audience.join(',')}]`,
           HTSGET_AUTH_VALIDATE_ISSUER: `[${issuer}]`,
           HTSGET_AUTH_TRUSTED_AUTHORIZATION_URLS: `[https://${auth_url}]`,
+          HTSGET_AUTH_SUPPRESS_ERRORS: true,
+          HTSGET_AUTH_ADD_HINT: true,
           AWS_LAMBDA_HTTP_IGNORE_STAGE_IN_PATH: true,
         },
       },

--- a/infrastructure/stage/htsget-stack.ts
+++ b/infrastructure/stage/htsget-stack.ts
@@ -10,7 +10,6 @@ import {
 } from '@orcabus/platform-cdk-constructs/api-gateway';
 import { IStringParameter, StringParameter } from 'aws-cdk-lib/aws-ssm';
 import path from 'path';
-import { spawnSync } from 'node:child_process';
 import { RustFunction } from 'cargo-lambda-cdk';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { NamedLambdaRole } from '@orcabus/platform-cdk-constructs/named-lambda-role';
@@ -92,20 +91,8 @@ export class HtsgetStack extends Stack {
     return [audience, issuer];
   }
 
-  private cargoLambdaFlags(htsgetFeatures: boolean): string[] {
-    const defaultTarget = spawnSync('rustc', ['--version', '--verbose'])
-      .stdout.toString()
-      .split(/\r?\n/)
-      .find((line) => line.startsWith('host:'))
-      ?.replace('host:', '')
-      .trim();
-
-    const flags = htsgetFeatures ? ['--features', 'aws', '--features', 'experimental'] : [];
-    if (defaultTarget === 'aarch64-unknown-linux-gnu') {
-      return [...flags, '--compiler', 'cargo'];
-    } else {
-      return flags;
-    }
+  private cargoLambdaFlags(): string[] {
+    return ['--features', 'aws', '--features', 'experimental', '--compiler', 'cargo'];
   }
 
   private htsGetAuthFunction(props: HtsgetStackProps, userPoolIdParam: IStringParameter): string {
@@ -128,7 +115,7 @@ export class HtsgetStack extends Stack {
         environment: {
           ...props.buildEnvironment,
         },
-        cargoLambdaFlags: this.cargoLambdaFlags(false),
+        cargoLambdaFlags: this.cargoLambdaFlags(),
       },
       memorySize: 128,
       timeout: Duration.seconds(28),
@@ -197,11 +184,11 @@ export class HtsgetStack extends Stack {
         },
       },
       buildEnvironment: props.buildEnvironment,
-      cargoLambdaFlags: this.cargoLambdaFlags(true),
+      cargoLambdaFlags: this.cargoLambdaFlags(),
       vpc: this.vpc,
       role,
       httpApi: apiGateway.httpApi,
-      gitReference: 'htsget-lambda-v0.7.3',
+      gitReference: 'htsget-lambda-v0.7.4',
       gitForceClone: false,
     });
   }

--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -52,7 +52,6 @@ export class StatelessStack extends cdk.Stack {
               "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
               'source $HOME/.cargo/env',
               'rustup component add rustfmt',
-              'npm install -g @ziglang/cli',
               'curl -fsSL https://cargo-lambda.info/install.sh | sh',
             ],
           },


### PR DESCRIPTION
### Changes
* Adds suppressed error feature from 0.7.4 htsget_lambda.
* Remove zig from installation as we are always compiling for the same architecture.
* Add and document restrictions.