### PR TITLE
ci: remove zig installation

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -72,7 +72,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: mlugg/setup-zig@v2
       - run: curl -fsSL https://cargo-lambda.info/install.sh | sh
 
       - uses: pnpm/action-setup@v4

--- a/infrastructure/stage/htsget-stack.ts
+++ b/infrastructure/stage/htsget-stack.ts
@@ -91,8 +91,9 @@ export class HtsgetStack extends Stack {
     return [audience, issuer];
   }
 
-  private cargoLambdaFlags(): string[] {
-    return ['--features', 'aws', '--features', 'experimental', '--compiler', 'cargo'];
+  private cargoLambdaFlags(htsgetFeatures: boolean): string[] {
+    const flags = htsgetFeatures ? ['--features', 'aws', '--features', 'experimental'] : [];
+    return [...flags, '--compiler', 'cargo'];
   }
 
   private htsGetAuthFunction(props: HtsgetStackProps, userPoolIdParam: IStringParameter): string {
@@ -115,7 +116,7 @@ export class HtsgetStack extends Stack {
         environment: {
           ...props.buildEnvironment,
         },
-        cargoLambdaFlags: this.cargoLambdaFlags(),
+        cargoLambdaFlags: this.cargoLambdaFlags(false),
       },
       memorySize: 128,
       timeout: Duration.seconds(28),
@@ -186,7 +187,7 @@ export class HtsgetStack extends Stack {
         },
       },
       buildEnvironment: props.buildEnvironment,
-      cargoLambdaFlags: this.cargoLambdaFlags(),
+      cargoLambdaFlags: this.cargoLambdaFlags(true),
       vpc: this.vpc,
       role,
       httpApi: apiGateway.httpApi,


### PR DESCRIPTION
### Changes
* Remove zig from ci as it's unused when compiling to the same architecture.